### PR TITLE
NEDS-132: Resolve conformance testing issues

### DIFF
--- a/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/config/enums/SMPPropertyEnum.java
+++ b/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/config/enums/SMPPropertyEnum.java
@@ -44,11 +44,11 @@ public enum SMPPropertyEnum {
     HTTP_PROXY_USER("smp.proxy.user", "", "The proxy user",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, STRING),
 
-    PARTC_SCH_VALIDATION_REGEXP("identifiersBehaviour.ParticipantIdentifierScheme.validationRegex", "^$|^(?!^.{26})([a-z0-9]+-[a-z0-9]+-[a-z0-9]+)$|^urn:oasis:names:tc:ebcore:partyid-type:(iso6523|unregistered)(:.+)?$",
+    PARTC_SCH_VALIDATION_REGEXP("identifiersBehaviour.ParticipantIdentifierScheme.validationRegex", "^$|^(?!^.{26})([A-Za-z0-9]+-[A-Za-z0-9]+-[A-Za-z0-9]+)$|^urn:oasis:names:tc:ebcore:partyid-type:(iso6523|unregistered)(:.+)?$",
             "Regular expression for validating the participant schema!",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, REGEXP),
     PARTC_SCH_REGEXP_MSG("identifiersBehaviour.ParticipantIdentifierScheme.validationRegexMessage",
-            "Participant scheme must start with:urn:oasis:names:tc:ebcore:partyid-type:(iso6523:|unregistered:) OR must be up to 25 characters long with form [domain]-[identifierArea]-[identifierType] (ex.: 'busdox-actorid-upis') and may only contain the following characters: [a-z0-9].", "Error message for UI",
+            "Participant scheme must start with:urn:oasis:names:tc:ebcore:partyid-type:(iso6523:|unregistered:) OR must be up to 25 characters long with form [domain]-[identifierArea]-[identifierType] (ex.: 'busdox-actorid-upis') and may only contain the following characters: [A-Za-z0-9].", "Error message for UI",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, STRING),
     PARTC_SCH_MANDATORY("identifiersBehaviour.scheme.mandatory", "true", "Scheme for participant identifier is mandatory",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, BOOLEAN),
@@ -57,6 +57,10 @@ public enum SMPPropertyEnum {
     PARTC_SCH_URN_REGEXP("identifiersBehaviour.ParticipantIdentifierScheme.urn.concatenate",
             "", "Regular expression to detect URN party identifiers. If the party identifier schema matches the regexp, then the party identifier is concatenated with a single colon in XML responses. Else it is handled as OASIS SMP party identifier. Example: ^(?i)(urn:)|(mailto:).*$",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, REGEXP),
+
+    PARTC_SCH_EBCORE_CONCAT_WITH_DOUBLE_COLON("identifiersBehaviour.ParticipantIdentifierScheme.ebCore.ConcatWithDoubleColon", "false",
+            "If true, concatenate ebCore participant identifiers using double colon",
+            OPTIONAL, NOT_ENCRYPTED, RESTART_NEEDED, BOOLEAN),
 
     CS_PARTICIPANTS("identifiersBehaviour.caseSensitive.ParticipantIdentifierSchemes", "sensitive-participant-sc1|sensitive-participant-sc2", "Specifies schemes of participant identifiers that must be considered CASE-SENSITIVE.",
             OPTIONAL, NOT_ENCRYPTED, NO_RESTART_NEEDED, LIST_STRING),

--- a/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/conversion/IdentifierService.java
+++ b/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/conversion/IdentifierService.java
@@ -35,16 +35,19 @@ import java.util.regex.Pattern;
 public class IdentifierService {
     private static final SMPLogger LOG = SMPLoggerFactory.getLogger(IdentifierService.class);
 
-    IdentifierFormatter participantIdentifierFormatter = IdentifierFormatter.Builder
-            .create()
-            .addFormatterTypes(new EBCorePartyIdFormatterType())
-            .build();
+    IdentifierFormatter participantIdentifierFormatter;
     IdentifierFormatter documentIdentifierFormatter = IdentifierFormatter.Builder.create().build();
 
     ConfigurationService configurationService;
 
     public IdentifierService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+
+        participantIdentifierFormatter = IdentifierFormatter.Builder
+                .create()
+                .addFormatterTypes(new EBCorePartyIdFormatterType(
+                        configurationService.getParticipantIdentifierEbcoreConcatWithDoubleColon()))
+                .build();
     }
 
     /**

--- a/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/identifiers/types/EBCorePartyIdFormatterType.java
+++ b/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/identifiers/types/EBCorePartyIdFormatterType.java
@@ -32,7 +32,19 @@ public class EBCorePartyIdFormatterType implements FormatterType {
     public static final String EBCORE_IDENTIFIER_UNREGISTERED_SCHEME = "unregistered";
     private static final String EBCORE_SEPARATOR = ":";
     private static final String OASIS_SMP_SEPARATOR = "::";
+    private final String separator;
 
+    public EBCorePartyIdFormatterType() {
+        this(false);
+    }
+
+    public EBCorePartyIdFormatterType(boolean useOasisSmpSeparator) {
+        if (useOasisSmpSeparator) {
+            separator = OASIS_SMP_SEPARATOR;
+        } else {
+            separator = EBCORE_SEPARATOR;
+        }
+    }
 
     @Override
     public boolean isTypeByScheme(final String scheme) {
@@ -54,7 +66,7 @@ public class EBCorePartyIdFormatterType implements FormatterType {
 
     @Override
     public String format(String scheme, String identifier, boolean noDelimiterOnEmptyScheme) {
-        return (isBlank(scheme) && noDelimiterOnEmptyScheme ? "" : trimToEmpty(scheme) + EBCORE_SEPARATOR) + trimToEmpty(identifier);
+        return (isBlank(scheme) && noDelimiterOnEmptyScheme ? "" : trimToEmpty(scheme) + separator) + trimToEmpty(identifier);
     }
 
     @Override

--- a/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/services/ConfigurationService.java
+++ b/smp-server-library/src/main/java/eu/europa/ec/edelivery/smp/services/ConfigurationService.java
@@ -555,5 +555,9 @@ public class ConfigurationService {
         return configurationDAO.getCachedPropertyValue(SMP_ALERT_MAIL_FROM);
     }
 
+    public boolean getParticipantIdentifierEbcoreConcatWithDoubleColon() {
+        Boolean value = configurationDAO.getCachedPropertyValue(PARTC_SCH_EBCORE_CONCAT_WITH_DOUBLE_COLON);
+        return value != null && value;
+    }
 
 }

--- a/smp-webapp/src/test/java/eu/europa/ec/edelivery/smp/ui/external/ApplicationResourceIntegrationTest.java
+++ b/smp-webapp/src/test/java/eu/europa/ec/edelivery/smp/ui/external/ApplicationResourceIntegrationTest.java
@@ -1,12 +1,5 @@
 package eu.europa.ec.edelivery.smp.ui.external;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.europa.ec.edelivery.smp.config.enums.SMPPropertyEnum;
 import eu.europa.ec.edelivery.smp.data.ui.SmpConfigRO;
@@ -14,6 +7,8 @@ import eu.europa.ec.edelivery.smp.data.ui.SmpInfoRO;
 import eu.europa.ec.edelivery.smp.test.SmpTestWebAppConfig;
 import eu.europa.ec.edelivery.smp.ui.ResourceConstants;
 import org.hamcrest.MatcherAssert;
+import org.junit.*;
+import org.junit.runner.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockServletContext;
@@ -29,12 +24,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
 import static eu.europa.ec.edelivery.smp.test.testutils.MockMvcUtils.loginWithSystemAdmin;
 import static eu.europa.ec.edelivery.smp.test.testutils.MockMvcUtils.loginWithUserGroupAdmin;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -162,8 +158,8 @@ public class ApplicationResourceIntegrationTest {
         SmpConfigRO res = mapper.readValue(value, SmpConfigRO.class);
 
         assertNotNull(res);
-        assertEquals("Participant scheme must start with:urn:oasis:names:tc:ebcore:partyid-type:(iso6523:|unregistered:) OR must be up to 25 characters long with form [domain]-[identifierArea]-[identifierType] (ex.: 'busdox-actorid-upis') and may only contain the following characters: [a-z0-9].", res.getParticipantSchemaRegExpMessage());
-        assertEquals("^$|^(?!^.{26})([a-z0-9]+-[a-z0-9]+-[a-z0-9]+)$|^urn:oasis:names:tc:ebcore:partyid-type:(iso6523|unregistered)(:.+)?$", res.getParticipantSchemaRegExp());
+        assertEquals(SMPPropertyEnum.PARTC_SCH_REGEXP_MSG.getDefValue(), res.getParticipantSchemaRegExpMessage());
+        assertEquals(SMPPropertyEnum.PARTC_SCH_VALIDATION_REGEXP.getDefValue(), res.getParticipantSchemaRegExp());
         assertEquals(SMPPropertyEnum.PARTC_EBCOREPARTYID_CONCATENATE.getDefValue(), res.isConcatEBCorePartyId() + "");
         assertFalse(res.isSmlIntegrationOn());
     }


### PR DESCRIPTION
* Make participant identifier validation regex accept A-Z in identifiers
* New config property identifiersBehaviour.ParticipantIdentifierScheme.ebCore.ConcatWithDoubleColon for using double colon when concatenating participant identifier scheme and id (required by conformance testing, but violates specification). Defaults to false, requires restart to change.