### PR TITLE
NEDS-246: Moved landing page inline JavaScript to an external file to comply with CSP

### DIFF
--- a/smp-webapp/src/main/java/eu/europa/ec/edelivery/smp/config/SMPWebAppConfig.java
+++ b/smp-webapp/src/main/java/eu/europa/ec/edelivery/smp/config/SMPWebAppConfig.java
@@ -121,7 +121,8 @@ public class SMPWebAppConfig implements WebMvcConfigurer {
                         "/images/oasis-smp-1.png",
                         "/images/oasis-smp-2.png",
                         "/images/favicon.ico",
-                        "/styles/domismp.css")
+                        "/styles/domismp.css",
+                        "/scripts/smp.js")
                 .addResourceLocations("/html/");
 
         registry.setOrder(HIGHEST_ORDER - 2)

--- a/smp-webapp/src/main/java/eu/europa/ec/edelivery/smp/controllers/RootController.java
+++ b/smp-webapp/src/main/java/eu/europa/ec/edelivery/smp/controllers/RootController.java
@@ -53,6 +53,7 @@ public class RootController {
 
     private final Map<String, String[]> STATIC_RESOURCES = Collections.unmodifiableMap(new HashMap() {{
         put("domismp.css", new String[]{"text/css", "/html/styles/domismp.css"});
+        put("smp.js", new String[]{"application/javascript", "/html/scripts/smp.js"});
         put("DomiSMP_logo.svg", new String[]{"image/svg+xml", "/html/images/DomiSMP_logo.svg"});
         put("EC+Logo2.png", new String[]{"image/png", "/html/images/EC+Logo2.png"});
         put("oasis-smp-1.png", new String[]{"image/png", "/html/images/oasis-smp-1.png"});
@@ -74,6 +75,7 @@ public class RootController {
     @GetMapping(produces = {MediaType.TEXT_HTML_VALUE,
             MediaType.IMAGE_PNG_VALUE,
             "text/css",
+            "application/javascript",
             "image/ico",
             "image/x-ico",
             "image/svg+xml"
@@ -83,7 +85,8 @@ public class RootController {
             "/images/oasis-smp-1.png",
             "/images/oasis-smp-2.png",
             "/images/favicon.ico",
-            "/styles/domismp.css"})
+            "/styles/domismp.css",
+            "/scripts/smp.js"})
     @ResponseBody
     public ResponseEntity<InputStreamResource> getStaticResources(HttpServletRequest httpReq) {
         String host = getRemoteHost(httpReq);

--- a/smp-webapp/src/main/resources/html/index.html
+++ b/smp-webapp/src/main/resources/html/index.html
@@ -23,16 +23,7 @@ limitations under the License.
   <link rel="icon" type="image/x-icon"
         href="images/favicon.ico"/>
   <link rel="stylesheet" href="styles/domismp.css"/>
-
-  <script type="text/javascript">
-
-    function toggleToolbar() {
-      const toolbar = document.getElementById('toolbar');
-      const content = document.getElementById('content');
-      toolbar.classList.toggle('tb-collapsed');
-      content.classList.toggle('tb-collapsed');
-    }
-  </script>
+  <script type="text/javascript" src="scripts/smp.js" defer="defer"></script>
 </head>
 <body>
 <div class="toolbar" id="toolbar">
@@ -53,7 +44,12 @@ limitations under the License.
     <span class="action-icon icon-oasis-logo-old">&nbsp;</span>
     <span class="action-label">Oasis SMP 1.0</span></a>
 
-  <button class="toggle-button" onclick="toggleToolbar()">
+  <button id="toolbarToggleButton"
+          class="toggle-button"
+          type="button"
+          aria-controls="toolbar"
+          aria-expanded="true"
+          title="Toggle toolbar">
     <span id="expanded">&#x2770;</span>
     <span id="collapsed">&#x2771;</span>
   </button>

--- a/smp-webapp/src/main/resources/html/scripts/smp.js
+++ b/smp-webapp/src/main/resources/html/scripts/smp.js
@@ -1,0 +1,34 @@
+(function () {
+  "use strict";
+
+  function setButtonState(button, isCollapsed) {
+    button.setAttribute("aria-expanded", String(!isCollapsed));
+  }
+
+  function toggleToolbar(toolbar, content, button) {
+    toolbar.classList.toggle("tb-collapsed");
+    content.classList.toggle("tb-collapsed");
+    setButtonState(button, toolbar.classList.contains("tb-collapsed"));
+  }
+
+  function initToolbarToggle() {
+    const toolbar = document.getElementById("toolbar");
+    const content = document.getElementById("content");
+    const button = document.getElementById("toolbarToggleButton");
+
+    if (!toolbar || !content || !button) {
+      return;
+    }
+
+    setButtonState(button, toolbar.classList.contains("tb-collapsed"));
+    button.addEventListener("click", function () {
+      toggleToolbar(toolbar, content, button);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initToolbarToggle);
+  } else {
+    initToolbarToggle();
+  }
+})();

--- a/smp-webapp/src/test/java/eu/europa/ec/edelivery/smp/controllers/RootControllerTest.java
+++ b/smp-webapp/src/test/java/eu/europa/ec/edelivery/smp/controllers/RootControllerTest.java
@@ -55,6 +55,7 @@ class RootControllerTest {
             "/favicon.ico, image/x-ico",
             "images/favicon.ico, image/x-ico",
             "styles/domismp.css, text/css",
+            "scripts/smp.js, application/javascript",
             "images/DomiSMP_logo.svg, image/svg+xml",
             "images/EC+Logo2.png, image/png",
             "images/oasis-smp-1.png, image/png",


### PR DESCRIPTION
Moved landing page inline JavaScript to an external file, required by the CSP definition added in harmony-common [#107](https://github.com/nordic-institute/harmony-common/pull/107)